### PR TITLE
chore(build): fix gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,11 +9,14 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    env:
+      HAS_GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        if: ${{ env.HAS_GITLEAKS_LICENSE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary
- fix the gitleaks workflow license guard
- pin `gitleaks/gitleaks-action` to commit `ff98106e4c7b2bc287b24eaf42907196329070c7`

## Validation
- this workflow shape was validated in `questdb/saas-sample-data-loader#4`
